### PR TITLE
feat: remove redundant renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,10 @@ jspm_packages/
 # Typescript v1 declaration files
 typings/
 
-# Optional npm cache directory
+# Cache
 .npm
-
-# Optional eslint cache
 .eslintcache
+.parcel-cache
 
 # Optional REPL history
 .node_repl_history


### PR DESCRIPTION
This pull request removes unnecessary re-renders by replacing related useState hook calls with one useReducer call.

Please merge after #27. Feel free to notify me before merging so that I can rebase it onto the master. 